### PR TITLE
Add speech recognition feature

### DIFF
--- a/backend/docs/api-specifications.md
+++ b/backend/docs/api-specifications.md
@@ -55,6 +55,29 @@ Creates a new item.
     }
     ```
 
+### POST /recognize-speech
+
+Recognizes speech from an audio file.
+
+- **URL**: `/recognize-speech`
+- **Method**: `POST`
+- **Request Body**:
+  - `Content-Type`: `multipart/form-data`
+  - **Example**:
+    ```sh
+    curl -X POST "http://localhost:8000/recognize-speech" -H "accept: application/json" -H "Content-Type: multipart/form-data" -F "file=@path_to_audio_file" -F "model=base"
+    ```
+- **Response**:
+  - `200 OK`: Returns the recognized speech transcript and language.
+  - `Content-Type`: `application/json`
+  - **Example**:
+    ```json
+    {
+      "transcript": "This is a sample transcript.",
+      "language": "en"
+    }
+    ```
+
 ## Usage
 
 To interact with the API, you can use tools like `curl`, Postman, or any HTTP client library in your preferred programming language. Below are some examples of how to use the API.
@@ -70,3 +93,13 @@ curl -X GET "http://localhost:8000/items" -H "accept: application/json"
 ```sh
 curl -X POST "http://localhost:8000/items" -H "accept: application/json" -H "Content-Type: application/json" -d '{"name":"New Item","description":"Description of the new item"}'
 ```
+
+### Example: Recognizing Speech
+
+```sh
+curl -X POST "http://localhost:8000/recognize-speech" -H "accept: application/json" -H "Content-Type: multipart/form-data" -F "file=@path_to_audio_file" -F "model=base"
+```
+
+## Further Documentation
+
+For further API documentation and testing, refer to the `/docs` endpoint provided by FastAPI.

--- a/backend/speech_recognition/speech_recognition.py
+++ b/backend/speech_recognition/speech_recognition.py
@@ -1,0 +1,32 @@
+import whisper
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from typing import Optional
+import os
+
+app = FastAPI()
+
+class SpeechRecognitionRequest(BaseModel):
+    model: Optional[str] = "turbo"
+
+model_cache = {}
+
+def get_model(model_name: str):
+    if model_name not in model_cache:
+        model_cache[model_name] = whisper.load_model(model_name)
+    return model_cache[model_name]
+
+@app.post("/recognize-speech")
+async def recognize_speech(file: UploadFile = File(...), model: str = "turbo"):
+    if file.content_type not in ["audio/wav", "audio/mpeg", "audio/mp3"]:
+        raise HTTPException(status_code=400, detail="Invalid file type")
+
+    audio_data = await file.read()
+    model = get_model(model)
+
+    result = model.transcribe(audio_data)
+    transcript = result["text"]
+    language = result["language"]
+
+    return JSONResponse(content={"transcript": transcript, "language": language})


### PR DESCRIPTION
Add speech recognition feature based on the provided YouTube video.

* **New Speech Recognition Implementation**
  - Create `backend/speech_recognition/speech_recognition.py` to implement speech recognition using the OpenAI Whisper module.
  - Add a FastAPI interface for the `/recognize-speech` endpoint to handle speech recognition requests.
  - Implement model caching and support for different audio file types.
  - Return the transcript and recognized language in the response.

* **API Documentation**
  - Update `backend/docs/api-specifications.md` to include the new `/recognize-speech` endpoint.
  - Document the request and response format for the new endpoint.
  - Add example usage for recognizing speech.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pkuppens/genai-hackathon/pull/2?shareId=318dda13-da38-4d40-af94-133d18027b4e).