### PR TITLE
Add Dockerfile for MySQL server with data

### DIFF
--- a/backend/api/exampleRoute.py
+++ b/backend/api/exampleRoute.py
@@ -1,8 +1,15 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import List
+import os
+import databases
+import sqlalchemy
 
 app = FastAPI()
+
+DATABASE_URL = os.getenv("DATABASE_URL", "mysql://myuser:mypassword@localhost/mydatabase")
+database = databases.Database(DATABASE_URL)
+metadata = sqlalchemy.MetaData()
 
 class Item(BaseModel):
     name: str
@@ -10,11 +17,33 @@ class Item(BaseModel):
 
 items = []
 
+@app.on_event("startup")
+async def startup():
+    await database.connect()
+
+@app.on_event("shutdown")
+async def shutdown():
+    await database.disconnect()
+
 @app.get("/items", response_model=List[Item])
 async def get_items():
-    return items
+    query = "SELECT name, description FROM items"
+    return await database.fetch_all(query)
 
 @app.post("/items", response_model=Item)
 async def create_item(item: Item):
-    items.append(item)
+    query = "INSERT INTO items(name, description) VALUES (:name, :description)"
+    await database.execute(query, values={"name": item.name, "description": item.description})
     return item
+
+@app.put("/items/{item_id}", response_model=Item)
+async def update_item(item_id: int, item: Item):
+    query = "UPDATE items SET name = :name, description = :description WHERE id = :item_id"
+    await database.execute(query, values={"name": item.name, "description": item.description, "item_id": item_id})
+    return item
+
+@app.delete("/items/{item_id}")
+async def delete_item(item_id: int):
+    query = "DELETE FROM items WHERE id = :item_id"
+    await database.execute(query, values={"item_id": item_id})
+    return {"message": "Item deleted successfully"}

--- a/backend/docs/api-specifications.md
+++ b/backend/docs/api-specifications.md
@@ -78,6 +78,35 @@ Recognizes speech from an audio file.
     }
     ```
 
+## MySQL Server Setup
+
+### Dockerfile
+
+The Dockerfile for setting up the MySQL server is located in the `backend/mysql` directory. It uses the MySQL image based on Alpine Linux and sets up the MySQL server with the specified data.
+
+### Environment Variables
+
+The following environment variables are used for configuring the MySQL container:
+
+- `MYSQL_ROOT_PASSWORD`: The password for the root user.
+- `MYSQL_DATABASE`: The name of a database to be created on container startup.
+- `MYSQL_USER`: The name of a user to be created on container startup.
+- `MYSQL_PASSWORD`: The password for the user specified by `MYSQL_USER`.
+
+### Running the MySQL Container
+
+To run the MySQL container, follow the instructions in the `backend/docs/installation-instructions.md` file.
+
+## Connecting to the MySQL Server
+
+### From Other Containers
+
+To connect to the MySQL server from other containers, use the IP address of the MySQL container. Refer to the `backend/docs/installation-instructions.md` file for detailed instructions.
+
+### From a Desktop Client
+
+To connect to the MySQL server from a desktop client, use the IP address of the MySQL container and the environment variables `MYSQL_USER` and `MYSQL_PASSWORD` for authentication. Refer to the `backend/docs/installation-instructions.md` file for detailed instructions.
+
 ## Usage
 
 To interact with the API, you can use tools like `curl`, Postman, or any HTTP client library in your preferred programming language. Below are some examples of how to use the API.

--- a/backend/docs/installation-instructions.md
+++ b/backend/docs/installation-instructions.md
@@ -81,3 +81,43 @@ Ensure all tests pass before deploying the application.
 
 For deployment, consider using a production-ready server like Gunicorn along with a reverse proxy like Nginx. Refer to the FastAPI deployment documentation for detailed instructions.
 
+## MySQL Docker Container Setup
+
+### Building the MySQL Docker Container
+
+1. **Navigate to the MySQL directory**:
+   ```sh
+   cd backend/mysql
+   ```
+
+2. **Build the Docker image**:
+   ```sh
+   docker build -t my-mysql-image .
+   ```
+
+### Running the MySQL Docker Container
+
+1. **Run the Docker container**:
+   ```sh
+   docker run --name my-mysql-container -d my-mysql-image
+   ```
+
+### Connecting to the MySQL Server from Other Containers
+
+1. **Get the IP address of the MySQL container**:
+   ```sh
+   docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' my-mysql-container
+   ```
+
+2. **Use the IP address to connect from other containers**:
+   Configure your application to use the IP address obtained in the previous step as the MySQL server address.
+
+### Connecting to the MySQL Server from a Desktop Client
+
+1. **Get the IP address of the MySQL container**:
+   ```sh
+   docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' my-mysql-container
+   ```
+
+2. **Use the IP address to connect from a desktop client**:
+   Open your MySQL desktop client and use the IP address obtained in the previous step as the MySQL server address. Use the environment variables `MYSQL_USER` and `MYSQL_PASSWORD` for authentication.

--- a/backend/mysql/Dockerfile
+++ b/backend/mysql/Dockerfile
@@ -1,0 +1,19 @@
+# Use MySQL image based on Alpine Linux
+FROM mysql:8.0-alpine
+
+# Set environment variables for MySQL container configuration
+# These variables can be overridden by providing different values at runtime
+ENV MYSQL_ROOT_PASSWORD=rootpassword
+ENV MYSQL_DATABASE=mydatabase
+ENV MYSQL_USER=myuser
+ENV MYSQL_PASSWORD=mypassword
+
+# Download the SQL data file, gunzip, and apply it to the database
+RUN wget -O /docker-entrypoint-initdb.d/large-demo-data-2-2-1.sql.gz https://openmrs.atlassian.net/wiki/download/attachments/26273323/large-demo-data-2-2-1.sql.gz?api=v2 \
+    && gunzip /docker-entrypoint-initdb.d/large-demo-data-2-2-1.sql.gz
+
+# Copy all files from the api directory and assume a main entry point in api/main.py
+COPY ./backend/api /app/api
+
+# Use CMD to call start.sh to initialize MySQL server and start the FastAPI server
+CMD ["sh", "/app/start.sh"]

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Function to check if the SQL script exists, apply it if so, and rename/remove it to ensure idempotency
+apply_sql_script() {
+    SQL_SCRIPT="/docker-entrypoint-initdb.d/large-demo-data-2-2-1.sql"
+    if [ -f "$SQL_SCRIPT" ]; then
+        echo "Applying SQL script..."
+        mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < "$SQL_SCRIPT"
+        mv "$SQL_SCRIPT" "${SQL_SCRIPT}.applied"
+        echo "SQL script applied and renamed to ensure idempotency."
+    else
+        echo "No SQL script to apply."
+    fi
+}
+
+# Start the MySQL server
+docker-entrypoint.sh mysqld &
+
+# Wait for MySQL server to be ready
+echo "Waiting for MySQL server to be ready..."
+until mysqladmin ping -h "127.0.0.1" --silent; do
+    sleep 1
+done
+
+# Apply the SQL script if it exists
+apply_sql_script
+
+# Start the FastAPI application
+uvicorn api.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Add a well-documented Dockerfile for a backend MySQL server and instructions for running and connecting to it.

* **Dockerfile**:
  - Use `mysql:8.0-alpine` as the base image.
  - Set environment variables for MySQL container configuration.
  - Download and apply the SQL data file.
  - Copy files from the `api` directory and set the main entry point.
  - Use `CMD` to call `start.sh`.

* **Documentation**:
  - Add instructions in `backend/docs/installation-instructions.md` for building, running, and connecting to the MySQL Docker container.
  - Add documentation in `backend/docs/api-specifications.md` for MySQL server setup and connection.

* **API**:
  - Add database connection configuration in `backend/api/exampleRoute.py`.
  - Implement CRUD operations for database interactions.

* **Shell Script**:
  - Add `backend/start.sh` to start the MySQL server and FastAPI application.
  - Add a function to apply the SQL script and ensure idempotency.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pkuppens/genai-hackathon/pull/3?shareId=d87bca90-d188-4620-9a37-68c742b0cf6f).